### PR TITLE
[espree] Import an Espree benchmark.

### DIFF
--- a/docs/in-depth.md
+++ b/docs/in-depth.md
@@ -86,6 +86,22 @@ popular.
 This benchmark runs the CoffeeScript compiler on the [`lexer.coffee`](https://github.com/bmeurer/web-tooling-benchmark/blob/resources/coffeescript-lexer-2.0.1.coffee)
 file from the CoffeeScript 2.0.1 distribution.
 
+## espree
+
+[Espree](https://github.com/eslint/espree) started out as a fork of Esprima v1.2.2,
+the last stable published released of Esprima before work on ECMAScript 6 began.
+Espree is now built on top of Acorn, which has a modular architecture that allows
+extension of core functionality. The goal of Espree is to produce output that is
+similar to Esprima with a similar API so that it can be used in place of Esprima.
+The popular analysis framework [ESLint](https://eslint.org) is built on Espree
+today.
+
+This benchmark runs Espree on a several common scripts, including
+- the [Backbone.js](http://backbonejs.org) 1.1.0 bundle,
+- the [jQuery](http://jquery.com) 3.2.1 distribution,
+- the [MooTools](https://mootools.net) 1.6.0 bundle,
+- and the [underscore](http://underscorejs.org/) 1.8.3 bundle.
+
 ## esprima
 
 [Esprima](http://esprima.org) is a high performance, standard-compliant ECMAScript parser

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "chai": "4.1.2",
     "coffeescript": "2.0.1",
     "compute-gmean": "^1.1.0",
+    "espree": "3.5.1",
     "esprima": "4.0.0",
     "jshint": "2.9.5",
     "lebab": "2.7.7",

--- a/src/espree-benchmark.js
+++ b/src/espree-benchmark.js
@@ -19,25 +19,24 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-const Benchmark = require("benchmark");
+const espree = require("espree");
+const fs = require("fs");
 
-const suite = new Benchmark.Suite();
+const payloads = [
+  "backbone-1.1.0.js",
+  "jquery-3.2.1.js",
+  "mootools-core-1.6.0.js",
+  "underscore-1.8.3.js"
+].map(name => fs.readFileSync(`resources/${name}`, "utf8"));
 
-suite.add(require("./acorn-benchmark"));
-suite.add(require("./babel-benchmark"));
-suite.add(require("./babylon-benchmark"));
-suite.add(require("./buble-benchmark"));
-suite.add(require("./chai-benchmark"));
-suite.add(require("./coffeescript-benchmark"));
-suite.add(require("./espree-benchmark"));
-suite.add(require("./esprima-benchmark"));
-suite.add(require("./jshint-benchmark"));
-suite.add(require("./lebab-benchmark"));
-suite.add(require("./prepack-benchmark"));
-suite.add(require("./prettier-benchmark"));
-suite.add(require("./source-map-benchmark"));
-suite.add(require("./typescript-benchmark"));
-suite.add(require("./uglify-js-benchmark"));
-suite.add(require("./uglify-es-benchmark"));
-
-module.exports = suite;
+module.exports = {
+  name: "espree",
+  fn() {
+    return payloads.map(payload => {
+      let count = 0;
+      count += espree.tokenize(payload, { loc: true, range: true }).length;
+      count += espree.parse(payload, { loc: true, range: true }).body.length;
+      return count;
+    });
+  }
+};


### PR DESCRIPTION
The benchmark is the same as for the esprima library. Espree is nowadays
the parser for ESLint.

This resolves #14.