### PR TITLE
[travis-ci] Also run the generated dist/run.js in the latest FF shell.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,12 @@ node_js:
     - "6"
     - "7"
     - "8"
+before_script:
+    - wget https://archive.mozilla.org/pub/firefox/nightly/latest-mozilla-central/jsshell-linux-x86_64.zip
+    - unzip jsshell-linux-x86_64.zip
+script:
+    - npm test
+    - ./js dist/run.js
 sudo: false
 branches:
     only:


### PR DESCRIPTION
Download the latest FirefoxNightly shell and run the `dist/run.js` through the
`js` shell to ensure that we don't break that.