### PR TITLE
Fix npm tasks on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "repository": "https://github.com/bmeurer/web-tooling-benchmark",
   "main": "src/cli.js",
   "scripts": {
-    "build:uglify-es-bundled": "./node_modules/uglify-es/bin/uglifyjs -b preamble=\"'const UglifyJS = module.exports = {};'\" --self > ./build/uglify-es-bundled.js",
-    "build:uglify-js-bundled": "./node_modules/uglify-js/bin/uglifyjs -b preamble=\"'const UglifyJS = module.exports = {};'\" --self > ./build/uglify-js-bundled.js",
+    "build:uglify-es-bundled": "node ./node_modules/uglify-es/bin/uglifyjs -b preamble=\"'const UglifyJS = module.exports = {};'\" --self > ./build/uglify-es-bundled.js",
+    "build:uglify-js-bundled": "node ./node_modules/uglify-js/bin/uglifyjs -b preamble=\"'const UglifyJS = module.exports = {};'\" --self > ./build/uglify-js-bundled.js",
     "build": "webpack",
     "postinstall": "npm run build:uglify-es-bundled && npm run build:uglify-js-bundled && npm run build",
     "precommit": "lint-staged",


### PR DESCRIPTION
Windows will never execute a JS file as if it were an executable. Windows cares not for your shebang line. This fixes the issue by explicitly invoking the node executable. Perhaps there is an even more portable way to do this...